### PR TITLE
adding command to script to exit on any command fail

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 rm -rf results
 mkdir -p build
@@ -8,6 +9,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 else
   cmake ..
 fi
+
 START=$(date +%s)
 make && make test ARGS="-VV"
 END=$(date +%s)


### PR DESCRIPTION
with set -e, any command in the build script that fails will cause the build to fail... without it, if you look at the output of a recent build, you can see the next to last line is the output of your build time calculator.  this command successfully runs, therefore overriding the exit code of the failed compilation.