### PR TITLE
build.sh now properly exits on failure

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,7 @@ else
 fi
 
 START=$(date +%s)
-make && make test ARGS="-VV"
+make
+make test ARGS="-VV"
 END=$(date +%s)
 echo "Total Build time (real) = $(( $END - $START )) seconds"


### PR DESCRIPTION
&& is a risky thing to use in bash, as it doesn't play well with set -e.  this will now properly fail the build when compilation fails.