### PR TITLE
Fix parallel build

### DIFF
--- a/libdialog/CMakeLists.txt
+++ b/libdialog/CMakeLists.txt
@@ -14,6 +14,7 @@ include_directories(${GTEST_INCLUDE_DIR}
 file(GLOB_RECURSE test_sources test/*.cc)
 add_executable(dtest ${test_sources})
 target_link_libraries(dtest ${TEST_LINK_LIBS})
+add_dependencies(dtest googletest)
 
 # install
 install(DIRECTORY dialog/

--- a/librpc/CMakeLists.txt
+++ b/librpc/CMakeLists.txt
@@ -22,17 +22,20 @@ set(SERVER_SOURCES src/dialog_constants.cc
                    src/dialog_types.cc)
 add_executable(dialogd ${SERVER_SOURCES})
 target_link_libraries(dialogd ${CMAKE_THREAD_LIBS_INIT} thriftstatic)
+add_dependencies(dialogd thrift)
 
 set(CLIENT_SOURCES src/dialog_constants.cc 
                    src/dialog_service.cc 
                    src/dialog_types.cc)
 add_library(dclient STATIC ${CLIENT_SOURCES})
 target_link_libraries(dclient thriftstatic)
+add_dependencies(dclient thrift)
 
 # Build test
 file(GLOB_RECURSE TEST_SOURCES test/*.cc)
 add_executable(rpctest ${TEST_SOURCES})
 target_link_libraries(rpctest ${TEST_LINK_LIBS} dclient thriftstatic)
+add_dependencies(rpctest googletest thrift)
 
 # install
 install(DIRECTORY rpc/


### PR DESCRIPTION
Add explicit dependencies between DiaLog targets and 3rd party libraries (thrift, googletest) so that parallel builds do not fail.