### PR TITLE
Add missing include

### DIFF
--- a/libconfluo/confluo/threads/periodic_task.h
+++ b/libconfluo/confluo/threads/periodic_task.h
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
+#include <functional>
 
 #include "atomic.h"
 #include "logger.h"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Using GCC 7.3.1 leads to compilation failure due to missing include in `confluo/threads/periodic_task.h` (See https://github.com/ucbrise/confluo/issues/119). This is resolved by adding 

```cpp
#include <functional>
```

to the header file.

## How was this patch tested?

This patch was tested manually on Amazon Linux AMI and MacOS with GCC 7.3.1.