### PR TITLE
Distinguish between normal tests and stress tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,10 @@ if (BUILD_TESTS)
   include(CTest)
 endif()
 
+if (BUILD_STRESS_TESTS)
+  add_definitions(-DSTRESS_TEST)
+endif()
+
 # Utilities
 add_subdirectory(libutils)
 

--- a/cmake-modules/BuildOptions.cmake
+++ b/cmake-modules/BuildOptions.cmake
@@ -2,6 +2,7 @@ include(CMakeDependentOption)
 
 # Components to build
 option(BUILD_TESTS "Build with unittests" ON)
+option(BUILD_STRESS_TESTS "Build with stress tests" OFF)
 option(BUILD_RPC "Build RPC framework" ON)
 option(BUILD_DOC "Build documentation" OFF)
 option(BUILD_EXAMPLES "Build examples" ON)


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Only run stress tests / expensive tests when a flag (`STRESS_TEST`) is passed in during build.
* This PR also fixes flaky `universal_sketch` tests. 