### PR TITLE
Improve the stability of Confluo thread management

### DIFF
--- a/examples/libstreaming/test/stream_test.h
+++ b/examples/libstreaming/test/stream_test.h
@@ -132,16 +132,12 @@ class StreamTest : public testing::Test {
     return builder.get_batch();
   }
 
+  std::shared_ptr<TServer> create_server(confluo_store *store) {
+    return rpc_server::create(store, SERVER_ADDRESS, SERVER_PORT);
+  }
+
  protected:
   uint8_t data_[DATA_SIZE];
-
-  virtual void SetUp() override {
-    thread_manager::register_thread();
-  }
-
-  virtual void TearDown() override {
-    thread_manager::deregister_thread();
-  }
 };
 
 StreamTest::rec StreamTest::r;
@@ -162,7 +158,7 @@ TEST_F(StreamTest, WriteTest) {
   dtable->add_index("g", 0.01);
   dtable->add_index("h");
 
-  auto server = rpc_server::create(store, SERVER_ADDRESS, SERVER_PORT);
+  auto server = create_server(store);
   std::thread serve_thread([&server] {
     server->serve();
   });
@@ -202,7 +198,7 @@ TEST_F(StreamTest, BufferTest) {
   auto store = simple_table_store(multilog_name, storage::IN_MEMORY);
   auto dtable = store->get_atomic_multilog(multilog_name);
   auto schema_size = dtable->get_schema().record_size();
-  auto server = rpc_server::create(store, SERVER_ADDRESS, SERVER_PORT);
+  auto server = create_server(store);
   std::thread serve_thread([&server] {
     server->serve();
   });
@@ -250,7 +246,7 @@ TEST_F(StreamTest, ReadTest) {
   dtable->add_index("g", 0.01);
   dtable->add_index("h");
 
-  auto server = rpc_server::create(store, SERVER_ADDRESS, SERVER_PORT);
+  auto server = create_server(store);
   std::thread serve_thread([&server] {
     server->serve();
   });
@@ -298,7 +294,7 @@ TEST_F(StreamTest, ReadWriteTest) {
   dtable->add_index("g", 0.01);
   dtable->add_index("h");
 
-  auto server = rpc_server::create(store, SERVER_ADDRESS, SERVER_PORT);
+  auto server = create_server(store);
   std::thread serve_thread([&server] {
     server->serve();
   });

--- a/libconfluo/confluo/conf/defaults.h
+++ b/libconfluo/confluo/conf/defaults.h
@@ -45,7 +45,9 @@ class defaults {
  public:
   /** The thread hardware concurrency */
   static inline int HARDWARE_CONCURRENCY() {
-    return std::thread::hardware_concurrency();
+    auto hw_concurrency = std::thread::hardware_concurrency();
+    // TODO: Print warning if hardware concurrency is 1
+    return hw_concurrency > 0 ? hw_concurrency : 1;
   }
 
   /** Default bucket size for index */

--- a/libconfluo/confluo/threads/thread_manager.h
+++ b/libconfluo/confluo/threads/thread_manager.h
@@ -12,12 +12,14 @@
 
 namespace confluo {
 
+typedef pthread_t thread_id_t;
+
 /**
  * Information about the thread
  */
 struct thread_info {
   /** The identifier of the thread */
-  std::thread::id tid;
+  thread_id_t tid;
   /** Whether the thread is valid */
   atomic::type<bool> valid;
 };
@@ -32,19 +34,19 @@ class thread_manager {
    * Registers a thread to the manager
    * @return The id of the thread
    */
-  static int register_thread();
+  static int register_thread(thread_id_t thread_id = pthread_self());
 
   /**
    * Deregisters the thread
    * @return The id of the deregistered thread
    */
-  static int deregister_thread();
+  static int deregister_thread(thread_id_t thread_id = pthread_self());
 
   /**
    * Finds the thread
    * @return The id of the found thread
    */
-  static int get_id();
+  static int get_id(thread_id_t thread_id = pthread_self());
 
   /**
    * Gets the maximum number of threads
@@ -65,14 +67,14 @@ class thread_manager {
    *
    * @return The identifier for the thread
    */
-  static int find();
+  static int find(thread_id_t thread_id);
 
   /**
    * Sets the thread identifier
    *
    * @return Integer representing the index of the thread 
    */
-  static int set();
+  static int set(thread_id_t thread_id );
 
   /**
    * Sets the thread to be invalid

--- a/libconfluo/src/filter.cc
+++ b/libconfluo/src/filter.cc
@@ -38,6 +38,9 @@ void filter::update(const record_t &r) {
         byte_string(r.timestamp() / configuration_params::TIME_RESOLUTION_NS()),
         r.log_offset(), aggregates_);
     int tid = thread_manager::get_id();
+    if (tid < 0) {
+      throw std::runtime_error("Thread is not registered");
+    }
     for (size_t i = 0; i < refs->num_aggregates(); i++) {
       if (aggregates_.at(i)->is_valid()) {
         size_t field_idx = aggregates_.at(i)->field_idx();
@@ -50,6 +53,9 @@ void filter::update(const record_t &r) {
 
 void filter::update(size_t log_offset, const schema_snapshot &snap, record_block &block, size_t record_size) {
   int tid = thread_manager::get_id();
+  if (tid < 0) {
+    throw std::runtime_error("Thread is not registered");
+  }
   aggregated_reflog *refs = nullptr;
   std::vector<numeric> local_aggs;
 

--- a/libconfluo/src/threads/thread_manager.cc
+++ b/libconfluo/src/threads/thread_manager.cc
@@ -2,23 +2,23 @@
 
 namespace confluo {
 
-int thread_manager::register_thread() {
+int thread_manager::register_thread(thread_id_t thread_id) {
   // De-register if already registered
-  deregister_thread();
-  int core_id = set();
+  deregister_thread(thread_id);
+  int core_id = set(thread_id);
   utils::thread_utils::set_self_core_affinity(core_id);
   return core_id;
 }
 
-int thread_manager::deregister_thread() {
+int thread_manager::deregister_thread(thread_id_t thread_id) {
   int core_id;
-  if ((core_id = find()) != -1)
+  if ((core_id = find(thread_id)) != -1)
     unset(core_id);
   return core_id;
 }
 
-int thread_manager::get_id() {
-  return find();
+int thread_manager::get_id(thread_id_t thread_id) {
+  return find(thread_id);
 }
 
 int thread_manager::get_max_concurrency() {
@@ -26,16 +26,15 @@ int thread_manager::get_max_concurrency() {
 }
 
 thread_info *thread_manager::init_thread_info() {
-  thread_info *tinfo = new thread_info[MAX_CONCURRENCY()];
+  auto *tinfo = new thread_info[MAX_CONCURRENCY()];
   for (int i = 0; i < thread_manager::MAX_CONCURRENCY(); i++)
     atomic::init(&tinfo[i].valid, false);
   return tinfo;
 }
 
-int thread_manager::find() {
-  auto tid = std::this_thread::get_id();
+int thread_manager::find(thread_id_t thread_id ) {
   for (int i = 0; i < thread_manager::MAX_CONCURRENCY(); i++) {
-    if (atomic::load(&THREAD_INFO()[i].valid) && THREAD_INFO()[i].tid == tid) {
+    if (atomic::load(&THREAD_INFO()[i].valid) && THREAD_INFO()[i].tid == thread_id) {
       return i;
     }
   }
@@ -43,12 +42,11 @@ int thread_manager::find() {
   return -1;
 }
 
-int thread_manager::set() {
-  auto tid = std::this_thread::get_id();
+int thread_manager::set(thread_id_t thread_id) {
   bool expected = false;
   for (int i = 0; i < thread_manager::MAX_CONCURRENCY(); i++) {
     if (atomic::strong::cas(&THREAD_INFO()[i].valid, &expected, true)) {
-      THREAD_INFO()[i].tid = tid;
+      THREAD_INFO()[i].tid = thread_id;
       return i;
     }
     expected = false;

--- a/libconfluo/src/threads/thread_manager.cc
+++ b/libconfluo/src/threads/thread_manager.cc
@@ -6,7 +6,7 @@ int thread_manager::register_thread(thread_id_t thread_id) {
   // De-register if already registered
   deregister_thread(thread_id);
   int core_id = set(thread_id);
-  utils::thread_utils::set_self_core_affinity(core_id);
+  utils::thread_utils::set_core_affinity(thread_id, core_id);
   return core_id;
 }
 

--- a/libconfluo/test/archival/filter_load_test.h
+++ b/libconfluo/test/archival/filter_load_test.h
@@ -23,6 +23,14 @@ class FilterLoadTest : public testing::Test {
   static const uint64_t kMillisecs = static_cast<const uint64_t>(1e6);
   static const uint64_t record_size = 16;
 
+  void SetUp() override {
+    thread_manager::register_thread();
+  }
+
+  void TearDown() override {
+    thread_manager::deregister_thread();
+  }
+
   struct data_point {
     int64_t ts;
     int64_t val;

--- a/librpc/CMakeLists.txt
+++ b/librpc/CMakeLists.txt
@@ -25,8 +25,10 @@ add_executable(confluod
         rpc/rpc_service.h
         rpc/rpc_record_batch_builder.h
         rpc/rpc_defaults.h
+        rpc/rpc_thread_factory.h
         rpc/rpc_types.h
         rpc/rpc_service.tcc
+        rpc/rpc_handler_registry.h
         src/rpc_constants.cc
         src/rpc_service.cc
         src/rpc_server.cc
@@ -36,13 +38,19 @@ add_executable(confluod
         src/rpc_record_batch_builder.cc
         src/rpc_record_stream.cc
         src/rpc_type_conversions.cc
-        src/confluo_server.cc)
+        src/confluo_server.cc
+        src/rpc_thread_factory.cc
+        src/rpc_handler_registry.cc)
 target_link_libraries(confluod confluo thriftstatic)
 add_dependencies(confluod thrift)
 
 add_library(rpcclient STATIC
         rpc/rpc_constants.h
         src/rpc_constants.cc
+        rpc/rpc_thread_factory.h
+        src/rpc_thread_factory.cc
+        rpc/rpc_handler_registry.h
+        src/rpc_handler_registry.cc
         rpc/rpc_server.h
         src/rpc_server.cc
         rpc/rpc_service.h
@@ -68,19 +76,6 @@ add_dependencies(rpcclient thrift)
 if (BUILD_TESTS)
   # Build test
   add_executable(rpctest
-          rpc/rpc_type_conversions.h
-          rpc/rpc_client.h
-          rpc/rpc_configuration_params.h
-          rpc/rpc_alert_stream.h
-          rpc/rpc_record_stream.h
-          rpc/rpc_server.h
-          rpc/rpc_constants.h
-          rpc/rpc_types.tcc
-          rpc/rpc_service.h
-          rpc/rpc_record_batch_builder.h
-          rpc/rpc_defaults.h
-          rpc/rpc_types.h
-          rpc/rpc_service.tcc
           test/client_read_ops_test.h
           test/test_main.cc
           test/client_connection_test.h

--- a/librpc/rpc/rpc_handler_registry.h
+++ b/librpc/rpc/rpc_handler_registry.h
@@ -1,0 +1,31 @@
+#ifndef CONFLUO_RPC_HANDLER_REGISTRY_H
+#define CONFLUO_RPC_HANDLER_REGISTRY_H
+
+#include <atomic>
+
+namespace confluo {
+namespace rpc {
+
+/**
+ * RPC handler registry
+ */
+class rpc_handler_registry {
+ public:
+  /**
+   * Add a handler to the registry.
+   *
+   * @return A unique identifier for the handler
+   */
+  static uint64_t add();
+
+  static void remove(uint64_t id);
+
+ private:
+  /** Current handler id **/
+  static std::atomic<uint64_t> handler_id_;
+};
+
+}
+}
+
+#endif //CONFLUO_RPC_HANDLER_REGISTRY_H

--- a/librpc/rpc/rpc_server.h
+++ b/librpc/rpc/rpc_server.h
@@ -4,6 +4,7 @@
 #include "rpc_service.h"
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/server/TThreadedServer.h>
+#include <thrift/server/TThreadPoolServer.h>
 #include <thrift/transport/TSocket.h>
 #include <thrift/transport/TServerSocket.h>
 #include <thrift/transport/TBufferTransports.h>
@@ -74,19 +75,19 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    * @param store The confluo store used to initialize the service
    * handler
    */
-  rpc_service_handler(confluo_store *store);
+  explicit rpc_service_handler(confluo_store *store);
 
   /**
    * Registers this service handler on a new thread
    * @throw management_expcetion If this service handler could not
    * be registered
    */
-  void register_handler();
+  void register_handler() override;
 
   /**
    * Deregisters this service handler and its associated thread
    */
-  void deregister_handler();
+  void deregister_handler() override;
 
   /**
    * Creates an atomic multilog from the given name, schema, and storage
@@ -100,7 +101,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    * @return ID associated with the atomic multilog, -1 if it could
    * not be created
    */
-  int64_t create_atomic_multilog(const std::string &name, const rpc_schema &schema, const rpc_storage_mode mode);
+  int64_t create_atomic_multilog(const std::string &name, const rpc_schema &schema, rpc_storage_mode mode) override;
 
   /**
    * Gets information about the atomic multilog
@@ -108,7 +109,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    * @param _return The info about the atomic multilog that is filled up
    * @param name The name of the atomic multilog
    */
-  void get_atomic_multilog_info(rpc_atomic_multilog_info &_return, const std::string &name);
+  void get_atomic_multilog_info(rpc_atomic_multilog_info &_return, const std::string &name) override;
 
   /**
    * Removes the atomic multilog with the matching ID
@@ -117,7 +118,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    * @throw management_excpetion If the atomic multilog could not be
    * removed
    */
-  void remove_atomic_multilog(int64_t id);
+  void remove_atomic_multilog(int64_t id) override;
 
   /**
    * Adds an index to a field in the atomic multilog
@@ -127,7 +128,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    * @param bucket_size The size of the bucket
    * @throw managmeent_exception If the index could not be added
    */
-  void add_index(int64_t id, const std::string &field_name, const double bucket_size);
+  void add_index(int64_t id, const std::string &field_name, double bucket_size) override;
 
   /**
    * Removes an index from a field in the atomic multilog
@@ -136,7 +137,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    * @param field_name The name of the field in the atomic multilog
    * @throw management_exception If the index could not be removed
    */
-  void remove_index(int64_t id, const std::string &field_name);
+  void remove_index(int64_t id, const std::string &field_name) override;
 
   /**
    * Adds a filter to the atomic multilog
@@ -149,7 +150,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    * expression
    */
   void add_filter(int64_t id, const std::string &filter_name,
-                  const std::string &filter_expr);
+                  const std::string &filter_expr) override;
 
   /**
    * Removes a filter from the atomic multilog
@@ -158,7 +159,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    * @param filter_name The name of the filter
    * @throw managment_exception If the filter could not be removed
    */
-  void remove_filter(int64_t id, const std::string &filter_name);
+  void remove_filter(int64_t id, const std::string &filter_name) override;
 
   /**
    * Adds an aggregate to the atomic multilog
@@ -173,7 +174,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
   void add_aggregate(int64_t id,
                      const std::string &aggregate_name,
                      const std::string &filter_name,
-                     const std::string &aggregate_expr);
+                     const std::string &aggregate_expr) override;
 
   /**
    * Removes an aggregate from the atomic multilog
@@ -182,7 +183,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    * @param aggregate_name The name of the aggregate
    * @throw management_exception If the aggregate could not be removed
    */
-  void remove_aggregate(int64_t id, const std::string &aggregate_name);
+  void remove_aggregate(int64_t id, const std::string &aggregate_name) override;
 
   /**
    * Adds a trigger to the atomic multilog
@@ -194,7 +195,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    * @throw parse_exception If the trigger expression could not be
    * parsed
    */
-  void add_trigger(int64_t id, const std::string &trigger_name, const std::string &trigger_expr);
+  void add_trigger(int64_t id, const std::string &trigger_name, const std::string &trigger_expr) override;
 
   /**
    * Removes a trigger from the atomic multilog
@@ -203,7 +204,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    * @param trigger_name The name of the trigger
    * @throw management_exception If the trigger could not be removed
    */
-  void remove_trigger(int64_t id, const std::string &trigger_name);
+  void remove_trigger(int64_t id, const std::string &trigger_name) override;
 
   /**
    * Appends string data to the atomic multilog
@@ -213,7 +214,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    *
    * @return The offset to where the data is
    */
-  int64_t append(int64_t id, const std::string &data);
+  int64_t append(int64_t id, const std::string &data) override;
 
   /**
    * Appends a record batch to the atomic multilog
@@ -223,7 +224,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    *
    * @return The offset where the batch is located
    */
-  int64_t append_batch(int64_t id, const rpc_record_batch &batch);
+  int64_t append_batch(int64_t id, const rpc_record_batch &batch) override;
 
   /**
    * Reads n record strings from the atomic multilog
@@ -233,7 +234,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    * @param offset The offset to read from
    * @param nrecords The number of records to read
    */
-  void read(std::string &_return, int64_t id, const int64_t offset, const int64_t nrecords);
+  void read(std::string &_return, int64_t id, int64_t offset, int64_t nrecords) override;
 
   /**
    * Queries an aggregate from the atomic multilog
@@ -248,7 +249,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
                        int64_t id,
                        const std::string &aggregate_name,
                        int64_t begin_ms,
-                       int64_t end_ms);
+                       int64_t end_ms) override;
 
   // TODO: Add tests
   /**
@@ -262,7 +263,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
   void adhoc_aggregate(std::string &_return,
                        int64_t id,
                        const std::string &aggregate_expr,
-                       const std::string &filter_expr);
+                       const std::string &filter_expr) override;
 
   /**
    * Executes an ad hoc filter
@@ -271,7 +272,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    * @param id The identifier of the atomic multilog
    * @param filter_expr The filter expression
    */
-  void adhoc_filter(rpc_iterator_handle &_return, int64_t id, const std::string &filter_expr);
+  void adhoc_filter(rpc_iterator_handle &_return, int64_t id, const std::string &filter_expr) override;
 
   /**
    * Queries a predefined filter
@@ -286,8 +287,8 @@ class rpc_service_handler : virtual public rpc_serviceIf {
   void predef_filter(rpc_iterator_handle &_return,
                      int64_t id,
                      const std::string &filter_name,
-                     const int64_t begin_ms,
-                     const int64_t end_ms);
+                     int64_t begin_ms,
+                     int64_t end_ms) override;
 
   /**
    * Queries a combined filter
@@ -304,8 +305,8 @@ class rpc_service_handler : virtual public rpc_serviceIf {
                        int64_t id,
                        const std::string &filter_name,
                        const std::string &filter_expr,
-                       const int64_t begin_ms,
-                       const int64_t end_ms);
+                       int64_t begin_ms,
+                       int64_t end_ms) override;
 
   /**
    * Gets the alerts from a time range
@@ -316,7 +317,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    * @param end_ms The end time in milliseconds
    * @throw rpc_invalid_exception If there was a duplicate rpc iterator
    */
-  void alerts_by_time(rpc_iterator_handle &_return, int64_t id, const int64_t begin_ms, const int64_t end_ms);
+  void alerts_by_time(rpc_iterator_handle &_return, int64_t id, int64_t begin_ms, int64_t end_ms) override;
 
   /**
    * Gets the alerts from a time range and by trigger
@@ -331,8 +332,8 @@ class rpc_service_handler : virtual public rpc_serviceIf {
   void alerts_by_trigger_and_time(rpc_iterator_handle &_return,
                                   int64_t id,
                                   const std::string &trigger_name,
-                                  const int64_t begin_ms,
-                                  const int64_t end_ms);
+                                  int64_t begin_ms,
+                                  int64_t end_ms) override;
 
   /**
    * Gets more from the map
@@ -341,7 +342,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    * @param id The identifier
    * @param desc The iterator description
    */
-  void get_more(rpc_iterator_handle &_return, int64_t id, const rpc_iterator_descriptor &desc);
+  void get_more(rpc_iterator_handle &_return, int64_t id, const rpc_iterator_descriptor &desc) override;
 
   /**
    * Gets the number of records from the store
@@ -350,7 +351,7 @@ class rpc_service_handler : virtual public rpc_serviceIf {
    *
    * @return The number of records
    */
-  int64_t num_records(int64_t id);
+  int64_t num_records(int64_t id) override;
 
  private:
   rpc_iterator_id new_iterator_id();
@@ -384,12 +385,12 @@ class rpc_clone_factory : public rpc_serviceIfFactory {
    *
    * @param store The confluo store for the rpc clone
    */
-  rpc_clone_factory(confluo_store *store);
+  explicit rpc_clone_factory(confluo_store *store);
 
   /**
    * Destructs the rpc clone factory
    */
-  virtual ~rpc_clone_factory();
+  ~rpc_clone_factory() override;
 
   /**
    * Gets the service handler for the rpc connection
@@ -398,14 +399,14 @@ class rpc_clone_factory : public rpc_serviceIfFactory {
    *
    * @return An rpc service handler for the confluo store
    */
-  virtual rpc_serviceIf *getHandler(const TConnectionInfo &conn_info);
+  rpc_serviceIf *getHandler(const TConnectionInfo &conn_info) override;
 
   /**
    * Destructs the handler
    *
    * @param handler The handler to destruct
    */
-  virtual void releaseHandler(rpc_serviceIf *handler);
+  void releaseHandler(rpc_serviceIf *handler) override;
 
  private:
   confluo_store *store_;
@@ -425,7 +426,8 @@ class rpc_server {
    *
    * @return A pointer to the server
    */
-  static std::shared_ptr<TThreadedServer> create(confluo_store *store, const std::string &address, int port);
+  static std::shared_ptr<TServer> create(confluo_store *store, const std::string &address,
+                                         int port, int num_workers = configuration_params::MAX_CONCURRENCY());
 };
 
 }

--- a/librpc/rpc/rpc_thread_factory.h
+++ b/librpc/rpc/rpc_thread_factory.h
@@ -1,0 +1,86 @@
+#ifndef CONFLUO_RPC_THREAD_FACTORY_H
+#define CONFLUO_RPC_THREAD_FACTORY_H
+
+#include <thrift/concurrency/Thread.h>
+#include <thrift/stdcxx.h>
+#include <thread>
+
+namespace confluo {
+namespace rpc {
+
+class rpc_thread_factory : public ::apache::thrift::concurrency::ThreadFactory {
+ public:
+  /**
+   * POSIX Thread scheduler policies
+   */
+  enum POLICY { OTHER, FIFO, ROUND_ROBIN };
+
+  /**
+   * POSIX Thread scheduler relative priorities,
+   *
+   * Absolute priority is determined by scheduler policy and OS. This
+   * enumeration specifies relative priorities such that one can specify a
+   * priority within a giving scheduler policy without knowing the absolute
+   * value of the priority.
+   */
+  enum PRIORITY {
+    LOWEST = 0,
+    LOWER = 1,
+    LOW = 2,
+    NORMAL = 3,
+    HIGH = 4,
+    HIGHER = 5,
+    HIGHEST = 6,
+    INCREMENT = 7,
+    DECREMENT = 8
+  };
+
+  explicit rpc_thread_factory(POLICY policy = ROUND_ROBIN,
+                              PRIORITY priority = NORMAL,
+                              int stackSize = 1,
+                              bool detached = false);
+
+  explicit rpc_thread_factory(bool detached);
+
+  // From ThreadFactory;
+  ::apache::thrift::stdcxx::shared_ptr<::apache::thrift::concurrency::Thread>
+  newThread(::apache::thrift::stdcxx::shared_ptr<::apache::thrift::concurrency::Runnable> runnable) const override;
+
+  // From ThreadFactory;
+  ::apache::thrift::concurrency::Thread::id_t getCurrentThreadId() const override;
+
+  /**
+    * Gets stack size for newly created threads
+    *
+    * @return int size in megabytes
+    */
+  virtual int getStackSize() const;
+
+  /**
+   * Sets stack size for newly created threads
+   *
+   * @param value size in megabytes
+   */
+  virtual void setStackSize(int value);
+
+  /**
+   * Gets priority relative to current policy
+   */
+  virtual PRIORITY getPriority() const;
+
+  /**
+   * Sets priority relative to current policy
+   */
+  virtual void setPriority(PRIORITY priority);
+
+ private:
+  POLICY policy_;
+  PRIORITY priority_;
+  int stackSize_;
+};
+
+}
+
+}
+
+#endif //CONFLUO_RPC_THREAD_FACTORY_H

--- a/librpc/rpc/rpc_thread_factory.h
+++ b/librpc/rpc/rpc_thread_factory.h
@@ -1,8 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 #ifndef CONFLUO_RPC_THREAD_FACTORY_H
 #define CONFLUO_RPC_THREAD_FACTORY_H
 
 #include <thrift/concurrency/Thread.h>
-#include <thrift/stdcxx.h>
 #include <thread>
 
 namespace confluo {
@@ -43,8 +61,8 @@ class rpc_thread_factory : public ::apache::thrift::concurrency::ThreadFactory {
   explicit rpc_thread_factory(bool detached);
 
   // From ThreadFactory;
-  ::apache::thrift::stdcxx::shared_ptr<::apache::thrift::concurrency::Thread>
-  newThread(::apache::thrift::stdcxx::shared_ptr<::apache::thrift::concurrency::Runnable> runnable) const override;
+  std::shared_ptr<::apache::thrift::concurrency::Thread>
+  newThread(std::shared_ptr<::apache::thrift::concurrency::Runnable> runnable) const override;
 
   // From ThreadFactory;
   ::apache::thrift::concurrency::Thread::id_t getCurrentThreadId() const override;

--- a/librpc/src/rpc_handler_registry.cc
+++ b/librpc/src/rpc_handler_registry.cc
@@ -1,0 +1,20 @@
+
+#include <rpc_handler_registry.h>
+
+#include "rpc_handler_registry.h"
+
+namespace confluo {
+namespace rpc {
+
+std::atomic<uint64_t> rpc_handler_registry::handler_id_{0};
+
+uint64_t rpc_handler_registry::add() {
+  return handler_id_.fetch_add(1ULL);
+}
+
+void rpc_handler_registry::remove(uint64_t) {
+  // Do nothing
+}
+
+}
+}

--- a/librpc/src/rpc_thread_factory.cc
+++ b/librpc/src/rpc_thread_factory.cc
@@ -1,0 +1,280 @@
+#include <utility>
+
+#include "rpc_thread_factory.h"
+
+#include <thrift/concurrency/Monitor.h>
+#include <rand_utils.h>
+#include <logger.h>
+#include <threads/thread_manager.h>
+
+using namespace ::apache::thrift::concurrency;
+using namespace ::apache::thrift;
+using namespace ::utils;
+
+namespace confluo {
+namespace rpc {
+
+class rpc_thread : public Thread {
+ public:
+  enum STATE { uninitialized, starting, started, stopping, stopped };
+
+  static const int MB = 1024 * 1024;
+
+  static void *threadMain(void *arg);
+
+ private:
+  pthread_t pthread_;
+  Monitor monitor_;        // guard to protect state_ and also notification
+  STATE state_;         // to protect proper thread start behavior
+  int priority_;
+  int stackSize_;
+  stdcxx::weak_ptr<rpc_thread> self_;
+  bool detached_;
+
+ public:
+  rpc_thread(int priority,
+             int stackSize,
+             bool detached,
+             stdcxx::shared_ptr<Runnable> runnable)
+      : pthread_(nullptr),
+        state_(uninitialized),
+        priority_(priority),
+        stackSize_(stackSize),
+        detached_(detached) {
+    this->Thread::runnable(std::move(runnable));
+  }
+
+  ~rpc_thread() override {
+    /* Nothing references this thread, if is is not detached, do a join
+       now, otherwise the thread-id and, possibly, other resources will
+       be leaked. */
+    if (!detached_) {
+      try {
+        join();
+      } catch (...) {
+        // We're really hosed.
+      }
+    }
+  }
+
+  STATE getState() const {
+    Synchronized sync(monitor_);
+    return state_;
+  }
+
+  void setState(STATE newState) {
+    Synchronized sync(monitor_);
+    state_ = newState;
+
+    // unblock start() with the knowledge that the thread has actually
+    // started running, which avoids a race in detached threads.
+    if (newState == started) {
+      monitor_.notify();
+    }
+  }
+
+  void start() override {
+    if (getState() != uninitialized) {
+      return;
+    }
+
+    pthread_attr_t thread_attr;
+    if (pthread_attr_init(&thread_attr) != 0) {
+      throw SystemResourceException("pthread_attr_init failed");
+    }
+
+    if (pthread_attr_setdetachstate(&thread_attr, detached_ ? PTHREAD_CREATE_DETACHED : PTHREAD_CREATE_JOINABLE)
+        != 0) {
+      throw SystemResourceException("pthread_attr_setdetachstate failed");
+    }
+
+    // Set thread stack size
+    if (pthread_attr_setstacksize(&thread_attr, static_cast<size_t>(MB * stackSize_)) != 0) {
+      throw SystemResourceException("pthread_attr_setstacksize failed");
+    }
+
+#if _POSIX_THREAD_PRIORITY_SCHEDULING > 0
+    if (pthread_attr_setschedpolicy(&thread_attr, policy_) != 0) {
+      throw SystemResourceException("pthread_attr_setschedpolicy failed");
+    }
+#endif
+
+    struct sched_param sched_param{};
+    sched_param.sched_priority = priority_;
+
+    // Set thread priority
+    if (pthread_attr_setschedparam(&thread_attr, &sched_param) != 0) {
+      throw SystemResourceException("pthread_attr_setschedparam failed");
+    }
+
+    // Create reference
+    auto *selfRef = new stdcxx::shared_ptr<rpc_thread>();
+    *selfRef = self_.lock();
+
+    setState(starting);
+
+    Synchronized sync(monitor_);
+
+    if (pthread_create(&pthread_, &thread_attr, threadMain, (void *) selfRef) != 0) {
+      throw SystemResourceException("pthread_create failed");
+    }
+
+    int id;
+    if ((id = thread_manager::register_thread(pthread_)) < 0) {
+      LOG_ERROR << "Failed to register thread " << (Thread::id_t) pthread_;
+    } else {
+      LOG_INFO << "Registered thread " << (Thread::id_t) pthread_ << " as " << id;
+    }
+
+    // The caller may not choose to guarantee the scope of the Runnable
+    // being used in the thread, so we must actually wait until the thread
+    // starts before we return.  If we do not wait, it would be possible
+    // for the caller to start destructing the Runnable and the Thread,
+    // and we would end up in a race.  This was identified with valgrind.
+    monitor_.wait();
+  }
+
+  void join() override {
+    int id;
+    if ((id = thread_manager::deregister_thread(pthread_)) < 0) {
+      LOG_ERROR << "Failed to deregister thread " << (Thread::id_t) pthread_;;
+    } else {
+      LOG_INFO << "Deregistered thread " << (Thread::id_t) pthread_ << " as " << id;
+    }
+    if (!detached_ && getState() != uninitialized) {
+      void *ignore;
+      /* XXX
+         If join fails it is most likely due to the fact
+         that the last reference was the thread itself and cannot
+         join.  This results in leaked threads and will eventually
+         cause the process to run out of thread resources.
+         We're beyond the point of throwing an exception.  Not clear how
+         best to handle this. */
+      int res = pthread_join(pthread_, &ignore);
+      detached_ = (res == 0);
+      if (res != 0) {
+        GlobalOutput.printf("rpc_thread::join(): fail with code %d", res);
+      }
+    }
+  }
+
+  Thread::id_t getId() override {
+    return (Thread::id_t) pthread_;
+  }
+
+  stdcxx::shared_ptr<Runnable> runnable() const override { return Thread::runnable(); }
+
+  void runnable(stdcxx::shared_ptr<Runnable> value) override { Thread::runnable(value); }
+
+  void weakRef(stdcxx::shared_ptr<rpc_thread> self) {
+    assert(self.get() == this);
+    self_ = stdcxx::weak_ptr<rpc_thread>(self);
+  }
+};
+
+void *rpc_thread::threadMain(void *arg) {
+  stdcxx::shared_ptr<rpc_thread> thread = *(stdcxx::shared_ptr<rpc_thread> *) arg;
+  delete reinterpret_cast<stdcxx::shared_ptr<rpc_thread> *>(arg);
+
+  thread->setState(started);
+  thread->runnable()->run();
+
+  STATE _s = thread->getState();
+  if (_s != stopping && _s != stopped) {
+    thread->setState(stopping);
+  }
+
+  return (void *) 0;
+}
+
+/**
+ * Converts generic posix thread schedule policy enums into pthread
+ * API values.
+ */
+static int toPthreadPolicy(rpc_thread_factory::POLICY policy) {
+  switch (policy) {
+    case rpc_thread_factory::OTHER:return SCHED_OTHER;
+    case rpc_thread_factory::FIFO:return SCHED_FIFO;
+    case rpc_thread_factory::ROUND_ROBIN:return SCHED_RR;
+  }
+  return SCHED_OTHER;
+}
+
+/**
+ * Converts relative thread priorities to absolute value based on posix
+ * thread scheduler policy
+ *
+ *  The idea is simply to divide up the priority range for the given policy
+ * into the correpsonding relative priority level (lowest..highest) and
+ * then pro-rate accordingly.
+ */
+static int toPthreadPriority(rpc_thread_factory::POLICY policy, rpc_thread_factory::PRIORITY priority) {
+  int pthread_policy = toPthreadPolicy(policy);
+  int min_priority = 0;
+  int max_priority = 0;
+#ifdef HAVE_SCHED_GET_PRIORITY_MIN
+  min_priority = sched_get_priority_min(pthread_policy);
+#endif
+#ifdef HAVE_SCHED_GET_PRIORITY_MAX
+  max_priority = sched_get_priority_max(pthread_policy);
+#endif
+  int quanta = (rpc_thread_factory::HIGHEST - rpc_thread_factory::LOWEST) + 1;
+  float stepsperquanta = (float) (max_priority - min_priority) / quanta;
+
+  if (priority <= rpc_thread_factory::HIGHEST) {
+    return (int) (min_priority + stepsperquanta * priority);
+  } else {
+    // should never get here for priority increments.
+    assert(false);
+    return (int) (min_priority + stepsperquanta * rpc_thread_factory::NORMAL);
+  }
+}
+
+rpc_thread_factory::rpc_thread_factory(rpc_thread_factory::POLICY policy,
+                                       rpc_thread_factory::PRIORITY priority,
+                                       int stackSize,
+                                       bool detached)
+    : ThreadFactory(detached), policy_(policy), priority_(priority), stackSize_(stackSize) {
+}
+
+rpc_thread_factory::rpc_thread_factory(bool detached)
+    : ThreadFactory(detached),
+      policy_(ROUND_ROBIN),
+      priority_(NORMAL),
+      stackSize_(1) {
+}
+
+stdcxx::shared_ptr<Thread> rpc_thread_factory::newThread(stdcxx::shared_ptr<Runnable> runnable) const {
+  stdcxx::shared_ptr<rpc_thread> result
+      = stdcxx::shared_ptr<rpc_thread>(new rpc_thread(
+          toPthreadPriority(policy_, priority_),
+          stackSize_,
+          isDetached(),
+          runnable));
+  result->weakRef(result);
+  runnable->thread(result);
+  return result;
+}
+
+::apache::thrift::concurrency::Thread::id_t rpc_thread_factory::getCurrentThreadId() const {
+  return (Thread::id_t) pthread_self();
+}
+
+int rpc_thread_factory::getStackSize() const {
+  return stackSize_;
+}
+
+void rpc_thread_factory::setStackSize(int value) {
+  stackSize_ = value;
+}
+
+rpc_thread_factory::PRIORITY rpc_thread_factory::getPriority() const {
+  return priority_;
+}
+
+void rpc_thread_factory::setPriority(rpc_thread_factory::PRIORITY value) {
+  priority_ = value;
+}
+
+}
+}

--- a/librpc/test/client_connection_test.h
+++ b/librpc/test/client_connection_test.h
@@ -27,8 +27,7 @@ TEST_F(ClientConnectionTest, ConcurrentConnectionsTest) {
   });
 
   rpc_test_utils::wait_till_server_ready(SERVER_ADDRESS, SERVER_PORT);
-  size_t num_clients = std::min((size_t)std::thread::hardware_concurrency(), (size_t)4);
-  std::vector<rpc_client> clients(num_clients);
+  std::vector<rpc_client> clients(4);
   for (auto &client : clients) {
     client.connect(SERVER_ADDRESS, SERVER_PORT);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR improves the stability of Confluo thread management, via the following changes:
* The thread manager now directly uses `pthread_t` handles as identifiers for the thread. This allows for cleaner use of `pthread_setaffinity_np`.
* Switches to `TThreadPoolServer` from `TThreadedServer` for the thrift RPC server. This allows using a single thread per thread in the pool, instead of using a single thread per handler.

The PR also introduces changes to make rest of the codebase consistent with the above two changes.

## How was this patch tested?

The patch passes all existing tests on thread manager and Confluo's RPC service.
