### PR TITLE
Docker alpine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.*
+Dockerfile*

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,0 +1,22 @@
+FROM alpine:latest
+
+EXPOSE 9090
+
+RUN apk update && apk add --no-cache \ 
+        build-base cmake boost-dev bash
+
+RUN mkdir -p /opt/confluo
+COPY . /opt/confluo
+
+WORKDIR /opt/confluo
+RUN mkdir build \
+    && cd build \
+    && cmake -DBUILD_TESTS=OFF -DWITH_PY_CLIENT=OFF -DWITH_JAVA_CLIENT=OFF .. \
+    && make install
+
+RUN mkdir -p /var/db
+VOLUME /var/db
+
+WORKDIR /opt/confluo
+ENTRYPOINT ["confluod"]
+CMD ["--address=0.0.0.0", "--port=9090", "--data-path=/var/db", "2>/var/log/confluo.stderr 1>/var/log/confluo.stdout"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,12 @@
+Dockerfiles for the Confluo project
+
+### Build docker image
+*Run this in root confluo directory*
+```
+docker build -f docker/Dockerfile.alpine -t confluo:alpine .
+```
+
+### Run image
+```
+docker run -p 9090:9090 -v <localdir>:/var/db confluo:alpine
+```

--- a/libconfluo/confluo/types/byte_string.h
+++ b/libconfluo/confluo/types/byte_string.h
@@ -252,7 +252,7 @@ class byte_string {
 #elif CONFLUO_ENDIANNESS == CONFLUO_LITTLE_ENDIAN
     uval = utils::byte_utils::byte_swap(uval);
 #else
-    uval = utils::byte_utils::is_big_endian() ? uval : byte_utils::byte_swap(uval);
+    uval = utils::byte_utils::is_big_endian() ? uval : utils::byte_utils::byte_swap(uval);
 #endif
     memcpy(data_, &uval, size_);
   }
@@ -272,7 +272,7 @@ class byte_string {
 #elif CONFLUO_ENDIANNESS == CONFLUO_LITTLE_ENDIAN
     val = utils::byte_utils::byte_swap(val);
 #else
-    val = byte_utils::is_big_endian() ? val : byte_utils::byte_swap(val);
+    val = utils::byte_utils::is_big_endian() ? val : utils::byte_utils::byte_swap(val);
 #endif
     memcpy(data_, &val, size_);
   }
@@ -436,7 +436,7 @@ class byte_string {
     if (utils::byte_utils::is_big_endian()) {
       val = *reinterpret_cast<T*>(data_);
     } else {
-      val = utils::byte_utils::reverse(data_, size_);
+      val = utils::byte_utils::reverse_as<T>(data_, size_);
     }
 #endif
     return val;

--- a/libutils/src/utils/error_handling.cc
+++ b/libutils/src/utils/error_handling.cc
@@ -2,6 +2,7 @@
 
 namespace utils {
 
+#ifdef __GLIBC__
 std::string error_handling::stacktrace() {
   std::ostringstream out;
   out << "stack trace: \n";
@@ -94,5 +95,6 @@ void error_handling::sighandler_stacktrace(int sig) {
   fprintf(stderr, "%s\n", stacktrace().c_str());
   exit(-1);
 }
+#endif
 
 }

--- a/libutils/utils/error_handling.h
+++ b/libutils/utils/error_handling.h
@@ -3,7 +3,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef __GLIBC__
 #include <execinfo.h>
+#endif
 #include <cxxabi.h>
 #include <dlfcn.h>
 #include <sstream>
@@ -22,14 +24,18 @@ class error_handling {
   template<typename ...args>
   static inline void install_signal_handler(const char *exec, int sig,
                                             args ... more) {
+#ifdef __GLIBC__
     signal(sig, error_handling::sighandler_stacktrace);
     error_handling::install_signal_handler(exec, std::forward<int>(more)...);
+#endif
   }
 
+#ifdef __GLIBC__
   static std::string stacktrace();
 
  private:
   static void sighandler_stacktrace(int sig);
+#endif
 };
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Dockerize confluo using alpine:latest image (smaller docker image size compared to ubuntu-based image - see #139)

## How was this patch tested?

* Able to build image and use confluo from outside.
* Needed to exclude some error_handling functions as build was failing
