### PR TITLE
Dockerize Confluo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.*
+Dockerfile*
+how.txt

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
 .*
 Dockerfile*
-how.txt

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -18,4 +18,4 @@ RUN mkdir -p /var/db
 VOLUME /var/db
 
 ENTRYPOINT ["confluod"]
-CMD ["--address=0.0.0.0", "--port=9090", "--data-path=/var/db", "2>/var/log/confluo.stderr 1>/var/log/confluo.stdout"]
+CMD ["--address=0.0.0.0", "--port=9090", "--data-path=/var/db"]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -1,0 +1,22 @@
+FROM ubuntu:latest
+
+EXPOSE 9090
+
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
+       build-essential cmake libboost-all-dev
+
+RUN mkdir -p /opt/confluo
+COPY . /opt/confluo
+
+WORKDIR /opt/confluo
+RUN mkdir build \
+    && cd build \
+    && cmake -DBUILD_TESTS=OFF -DWITH_PY_CLIENT=OFF -DWITH_JAVA_CLIENT=OFF .. \
+    && make -j8 install
+
+RUN mkdir -p /var/db
+VOLUME /var/db
+
+ENTRYPOINT ["confluod"]
+#CMD ["--address=0.0.0.0 --port=9090 -d /var/db 2>/var/log/confluo.stderr 1>/var/log/confluo.stdout"]
+CMD ["--address=0.0.0.0", "--port=9090", "--data-path=/var/db", "2>/var/log/confluo.stderr 1>/var/log/confluo.stdout"]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -18,5 +18,4 @@ RUN mkdir -p /var/db
 VOLUME /var/db
 
 ENTRYPOINT ["confluod"]
-#CMD ["--address=0.0.0.0 --port=9090 -d /var/db 2>/var/log/confluo.stderr 1>/var/log/confluo.stdout"]
 CMD ["--address=0.0.0.0", "--port=9090", "--data-path=/var/db", "2>/var/log/confluo.stderr 1>/var/log/confluo.stdout"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,12 +1,12 @@
-Dockerfiles for the Confluo project
+# Dockerfiles for the Confluo project
 
-### Build docker image
+## Build docker image
 *Run this in root confluo directory*
 ```
 docker build -f docker/Dockerfile.ubuntu -t confluo:ubuntu .
 ```
 
-### Run image
+## Run image
 ```
 docker run -p 9090:9090 -v <localdir>:/var/db confluo:ubuntu
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,12 @@
+Dockerfiles for the Confluo project
+
+### Build docker image
+*Run this in root confluo directory*
+```
+docker build -f docker/Dockerfile.ubuntu -t confluo:ubuntu .
+```
+
+### Run image
+```
+docker run -p 9090:9090 -v <localdir>:/var/db confluo:ubuntu
+```


### PR DESCRIPTION
## What changes were proposed in this pull request?

Here are proposed 2 options how to dockerize confluo project. One is based on ubuntu (require no code changes) and second is based on alpine with smaller image size (it require code changes in error_handling files).

We can decide to go only with one docker option or both.

## How was this patch tested?

Able to build both docker images.
