### PR TITLE
Fix compiling error when CMAKE_BUILD_TYPE=DEBUG (#142)

### DIFF
--- a/cmake-modules/Dependencies.cmake
+++ b/cmake-modules/Dependencies.cmake
@@ -112,7 +112,13 @@ if (BUILD_RPC)
                         "-DWITH_BOOSTTHREADS=OFF"
                         "-DWITH_STATIC_LIB=ON")
 
-  set(THRIFT_STATIC_LIB_NAME "${CMAKE_STATIC_LIBRARY_PREFIX}thrift")
+
+  if (CMAKE_BUILD_TYPE MATCHES DEBUG)
+    set(THRIFT_STATIC_LIB_NAME "${CMAKE_STATIC_LIBRARY_PREFIX}thriftd")
+  else ()
+    set(THRIFT_STATIC_LIB_NAME "${CMAKE_STATIC_LIBRARY_PREFIX}thrift")
+  endif ()
+
   set(THRIFT_STATIC_LIB "${THRIFT_PREFIX}/lib/${THRIFT_STATIC_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}")
   ExternalProject_Add(thrift
       URL "http://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix compiling error when build with CMAKE_BUILD_TYPE=DEBUG

## How was this patch tested?
cmake -DCMAKE_BUILD_TYPE=DEBUG ..

Passed  Under MaxOS and ubuntu16.04 

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Please review https://ucbrise.github.io/confluo/contributing/ before opening a pull request.
