### PR TITLE
Fix bug in loading multilog

### DIFF
--- a/libconfluo/confluo/atomic_multilog_metadata.h
+++ b/libconfluo/confluo/atomic_multilog_metadata.h
@@ -203,9 +203,9 @@ class metadata_writer {
   /**
    * Constructor that initializes metadata writer
    * @param path The path of where the metadata is
-   * @param id The id of the storage type 
+   * @param overwrite Whether or not to overwrite previous contents of file
    */
-  explicit metadata_writer(const std::string &path);
+  explicit metadata_writer(const std::string &path, bool overwrite = true);
 
   /**
    * Initializes the schema metadata writer


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix for #146

The main problem was that we weren't reading in the metadata correctly. 
- Don't overwrite the metadata before we can read it
- Fix how we check if there is metadata left to read (`has_next`)
- Fixed data log initialization
- Added a `default` case that throws an error to catch problems with corrupt files, bugs in reading etc

Also made minor formatting changes

## How was this patch tested?

Added a basic test that archives data, removes the log (to simulate failure) and loads it back in (simulate recovery).