### PR TITLE
Fix Jenkins build (python test dependencies)

### DIFF
--- a/pyclient/setup.py.in
+++ b/pyclient/setup.py.in
@@ -37,7 +37,7 @@ setup(name='confluo',
       package_dir={'conflo': 'confluo'},
       packages=['confluo.rpc'],
       setup_requires=['pytest-runner>=2.0,<4.0', 'thrift>=0.10.0'],
-      tests_require=['pytest-cov', 'pytest>2.0,<4.0', 'thrift>=${THRIFT_VERSION}'],
+      tests_require=['pytest>2.0,<4.0', 'pytest-cov', 'thrift>=${THRIFT_VERSION}'],
       install_requires=['thrift>=0.10.0'],
       cmdclass={'shell' : ConfluoShell}
       )

--- a/pyclient/setup.py.in
+++ b/pyclient/setup.py.in
@@ -37,7 +37,7 @@ setup(name='confluo',
       package_dir={'conflo': 'confluo'},
       packages=['confluo.rpc'],
       setup_requires=['pytest-runner>=2.0,<4.0', 'thrift>=0.10.0'],
-      tests_require=['pytest>2.0,<4.0', 'pytest-cov', 'thrift>=${THRIFT_VERSION}'],
+      tests_require=['pytest>2.0,<4.0', 'thrift>=${THRIFT_VERSION}'],
       install_requires=['thrift>=0.10.0'],
       cmdclass={'shell' : ConfluoShell}
       )


### PR DESCRIPTION
## Context
* Last green jenkins on master build was #1843
* It seems that later builds are failing because of pytest 5.x is used
and it dropped support for python 2.7 - see  https://github.com/pytest-dev/pytest/issues/5519

## What changes were proposed in this pull request?

* remove pytest-cov as this is (maybe) not essential for the build

## How was this patch tested?

We will test this using jenkins build pipeline

